### PR TITLE
Set credentials variable if already logged in on app start.

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -66,6 +66,7 @@ const Page = () => {
 
         const response = await apiValidateToken();
         if (response.valid_token == true) {
+            global.currentCredentials = await getCredentials();
             router.push('callout-list');
         } else {
             await clearCredentials();


### PR DESCRIPTION
This fixes the isSelf message bubble color.